### PR TITLE
[WIP]Fix: union type is not working [at type alias]

### DIFF
--- a/apps/test/src/test.ts
+++ b/apps/test/src/test.ts
@@ -31,3 +31,10 @@ let j = boostestMixCompTSAlias<MixCompTSAlias>({ name: 'mixCompTSAlias' });
 // TODO
 // import ClassObj from './types/class_obj';
 // let k = boostestClassObj<typeof ClassObj>(ClassObj);
+
+import { TSAliasMixUnionType, TSAliasStringUnionType, TSAliasMixUnionObjType, TSInterfaceMixUnionType, TSInterfaceStringUnionType } from './types/ts_types/union';
+let k = boostestTSAliasMixUnionType<TSAliasMixUnionType>('A');
+let l = boostestTSAliasStringUnionType<TSAliasStringUnionType>('A');
+let m = boostestTSInterfaceMixUnionType<TSInterfaceMixUnionType>({ type: 'A' });
+let n = boostestTSInterfaceStringUnionType<TSInterfaceStringUnionType>({ type: 'A' });
+let o = boostestTSAliasMixUnionObjType<TSAliasMixUnionObjType>({ ref_type: 'A', type: 'A' });

--- a/apps/test/src/test_test_data.ts
+++ b/apps/test/src/test_test_data.ts
@@ -546,3 +546,43 @@ export function conditionalKey_boostestMixCompTSAlias<T>(args?: Partial<T>): T {
 	} as T);
 }
 
+export function boostestTSAliasMixUnionObjType<T>(args?: Partial<T>): T {
+	return ({
+		'ref_type':ref_type_boostestTSAliasMixUnionObjType(),
+		'type':50000,
+		...args
+	} as T);
+}
+
+export function ref_type_boostestTSAliasMixUnionObjType<T>(args?: Partial<T>): T {
+	return ({
+		...args
+	} as T);
+}
+
+export function boostestTSAliasMixUnionType<T>(args?: Partial<T>): T {
+	return ({
+		...args
+	} as T);
+}
+
+export function boostestTSAliasStringUnionType<T>(args?: Partial<T>): T {
+	return ({
+		...args
+	} as T);
+}
+
+export function boostestTSInterfaceMixUnionType<T>(args?: Partial<T>): T {
+	return ({
+		'type':50000,
+		...args
+	} as T);
+}
+
+export function boostestTSInterfaceStringUnionType<T>(args?: Partial<T>): T {
+	return ({
+		'type':'A',
+		...args
+	} as T);
+}
+

--- a/apps/test/src/types/ts_types/union.ts
+++ b/apps/test/src/types/ts_types/union.ts
@@ -1,0 +1,14 @@
+export type TSAliasStringUnionType = 'A' | 'B' | 'C';
+export type TSAliasMixUnionType = 50000 | 'A' | 1 | true | TSAliasStringUnionType;
+
+export type TSAliasMixUnionObjType = {
+  ref_type: TSAliasMixUnionType;
+  type: 50000 | 'A' | 1 | true | TSAliasStringUnionType;
+};
+
+export interface TSInterfaceStringUnionType {
+  type: 'A' | 'B' | 'C';
+}
+export interface TSInterfaceMixUnionType {
+  type: 50000 | 'A' | 1 | true | TSAliasStringUnionType;
+}

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ debug:
   just debug_build
   pnpm --filter example start:boostest
 
+test_debug:
+  just debug_build
+  pnpm --filter test boostest
+
 update_snapshot:
   just debug_build
   pnpm --filter test snapshot  


### PR DESCRIPTION
Supportting `TSTypeAliasDeclaration` is needed for fixing the issue https://github.com/MasatoDev/boostest/issues/8.
If it is a property of object, union type works.


```bash
    + export function boostestTSAliasMixUnionObjType<T>(args?: Partial<T>): T {
    +   return ({
    +           'ref_type':ref_type_boostestTSAliasMixUnionObjType(),
    +           'type':50000,
    +           ...args
    +   } as T);
    + }
    +
    + export function ref_type_boostestTSAliasMixUnionObjType<T>(args?: Partial<T>): T {
    +   return ({
    +           ...args
    +   } as T);
    + }
    +
    + export function boostestTSAliasMixUnionType<T>(args?: Partial<T>): T {
    +   return ({
    +           ...args
    +   } as T);
    + }
    +
    + export function boostestTSAliasStringUnionType<T>(args?: Partial<T>): T {
    +   return ({
    +           ...args
    +   } as T);
    + }
    +
    + export function boostestTSInterfaceMixUnionType<T>(args?: Partial<T>): T {
    +   return ({
    +           'type':50000,
    +           ...args
    +   } as T);
    + }
    +
    + export function boostestTSInterfaceStringUnionType<T>(args?: Partial<T>): T {
    +   return ({
    +           'type':'A',
    +           ...args
    +   } as T);
    + }
    +
```